### PR TITLE
Fix submission script to correctly calculate size of slurm array afte…

### DIFF
--- a/examples/hcp-project/submit.sh
+++ b/examples/hcp-project/submit.sh
@@ -5,6 +5,7 @@ project_dir=/data/users2/jwardell1/nshor_docker/examples/hcp-project
 paths_file=${project_dir}/HCP/paths
 
 num_lines=`wc -l <  $paths_file`
-num_total_runs=$(( $num_lines / 9  ))
+num_total_runs=$(( $num_lines / 10 ))
+runix=$(( $num_total_runs - 1 ))
 
-sbatch --array=0-${num_total_runs}%4 ${project_dir}/procruns.job
+sbatch --array=0-${runix}%20 ${project_dir}/procruns.job


### PR DESCRIPTION
…r adding maskfile.

Fixed submission script to use number of runs -1 as the last index when indices begin with 0.